### PR TITLE
Add Turbo temporary attribute to SweetAlert scripts

### DIFF
--- a/src/Twig/Extension/AlertExtension.php
+++ b/src/Twig/Extension/AlertExtension.php
@@ -41,7 +41,7 @@ class AlertExtension extends AbstractExtension
             $stimulusAttributes->addController($name, $controllerValues);
         }
 
-        $html = \sprintf('<div %s></div>', $stimulusAttributes);
+        $html = \sprintf('<div data-turbo-temporary="true" %s></div>', $stimulusAttributes);
 
         return new Markup($html, 'UTF-8');
     }

--- a/tests/Twig/Extension/AlertExtensionTest.php
+++ b/tests/Twig/Extension/AlertExtensionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Pentiminax\UX\SweetAlert\Tests\Twig\Extension;
+
+use Pentiminax\UX\SweetAlert\AlertManagerInterface;
+use Pentiminax\UX\SweetAlert\ToastManagerInterface;
+use Pentiminax\UX\SweetAlert\Twig\Extension\AlertExtension;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+class AlertExtensionTest extends TestCase
+{
+    public function testScriptsAddsTurboTemporaryAttribute(): void
+    {
+        $twig = new Environment(new ArrayLoader());
+
+        $alertManager = $this->createMock(AlertManagerInterface::class);
+        $alertManager
+            ->expects($this->once())
+            ->method('getAlerts')
+            ->willReturn([]);
+
+        $toastManager = $this->createMock(ToastManagerInterface::class);
+        $toastManager
+            ->expects($this->once())
+            ->method('getToasts')
+            ->willReturn([]);
+
+        $extension = new AlertExtension($twig, $alertManager, $toastManager);
+
+        $markup = $extension->scripts();
+
+        $this->assertStringContainsString('data-turbo-temporary', (string) $markup);
+    }
+}


### PR DESCRIPTION
## Summary
- mark the SweetAlert scripts container as Turbo temporary to avoid snapshot persistence
- add a regression test ensuring the scripts markup retains the Turbo temporary attribute

## Testing
- not run (composer install failed: curl error 56 while downloading packages.json)

------
https://chatgpt.com/codex/tasks/task_e_68ed65d227dc832aa95ed4eda25a0b20