### PR TITLE
feat: add input type alert action

### DIFF
--- a/src/AlertManager.php
+++ b/src/AlertManager.php
@@ -6,6 +6,7 @@ use Pentiminax\UX\SweetAlert\Context\SweetAlertContextInterface;
 use Pentiminax\UX\SweetAlert\Enum\Icon;
 use Pentiminax\UX\SweetAlert\Enum\Position;
 use Pentiminax\UX\SweetAlert\Enum\Theme;
+use Pentiminax\UX\SweetAlert\InputType\InputTypeInterface;
 use Pentiminax\UX\SweetAlert\Model\Alert;
 use Pentiminax\UX\SweetAlert\Model\AlertDefaults;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -19,8 +20,7 @@ class AlertManager implements AlertManagerInterface
         private readonly FlashMessageConverter $flashMessageConverter,
         private readonly AlertDefaults $alertDefaults,
         private readonly bool $autoConvertFlashMessages = false,
-    ) {
-    }
+    ) {}
 
     public function addAlert(Alert $alert): void
     {
@@ -155,7 +155,7 @@ class AlertManager implements AlertManagerInterface
         );
     }
 
-    private function createAndAddAlert(
+    private function createAlert(
         string $id,
         string $title,
         string $text,
@@ -193,6 +193,44 @@ class AlertManager implements AlertManagerInterface
                 $alert->withTimerProgressBar();
             }
         }
+
+        return $alert;
+    }
+    public function input(
+        InputTypeInterface $inputType,
+        string $title,
+        string $id = '',
+        string $text = '',
+        ?Icon $icon = null,
+        Position $position = Position::CENTER,
+        ?Theme $theme = null,
+        array $customClass = [],
+        bool $toast = false,
+        ?int $timer = null,
+        bool $timerProgressBar = false,
+    ): Alert {
+        $alert = $this->createAlert($id, $title, $text, $position, $theme, $icon, $customClass, $toast, $timer, $timerProgressBar);
+
+        $inputType->configure($alert);
+
+        $this->addAlert($alert);
+
+        return $alert;
+    }
+
+    private function createAndAddAlert(
+        string $id,
+        string $title,
+        string $text,
+        Position $position,
+        ?Theme $theme,
+        ?Icon $icon,
+        array $customClass = [],
+        bool $toast = false,
+        ?int $timer = null,
+        bool $timerProgressBar = false,
+    ): Alert {
+        $alert = $this->createAlert($id, $title, $text, $position, $theme, $icon, $customClass, $toast, $timer, $timerProgressBar);
 
         $this->addAlert($alert);
 

--- a/src/AlertManagerInterface.php
+++ b/src/AlertManagerInterface.php
@@ -5,6 +5,7 @@ namespace Pentiminax\UX\SweetAlert;
 use Pentiminax\UX\SweetAlert\Enum\Icon;
 use Pentiminax\UX\SweetAlert\Enum\Position;
 use Pentiminax\UX\SweetAlert\Enum\Theme;
+use Pentiminax\UX\SweetAlert\InputType\InputTypeInterface;
 use Pentiminax\UX\SweetAlert\Model\Alert;
 
 interface AlertManagerInterface
@@ -85,6 +86,20 @@ interface AlertManagerInterface
         ?Icon $icon = Icon::SUCCESS,
         Position $position = Position::BOTTOM_END,
         ?Theme $theme = null,
+        ?int $timer = null,
+        bool $timerProgressBar = false,
+    ): Alert;
+
+    public function input(
+        InputTypeInterface $inputType,
+        string $title,
+        string $id = '',
+        string $text = '',
+        ?Icon $icon = null,
+        Position $position = Position::CENTER,
+        ?Theme $theme = null,
+        array $customClass = [],
+        bool $toast = false,
         ?int $timer = null,
         bool $timerProgressBar = false,
     ): Alert;

--- a/src/InputType/InputTypeInterface.php
+++ b/src/InputType/InputTypeInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\SweetAlert\InputType;
+
+use Pentiminax\UX\SweetAlert\Model\Alert;
+
+interface InputTypeInterface
+{
+    public function configure(Alert $alert): void;
+}

--- a/src/InputType/Text.php
+++ b/src/InputType/Text.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\SweetAlert\InputType;
+
+use Pentiminax\UX\SweetAlert\Model\Alert;
+
+final class Text implements InputTypeInterface
+{
+    private string $input = 'text';
+
+    public function __construct(
+        private readonly ?string $label = null,
+        private readonly ?string $value = null,
+        private readonly ?string $placeholder = null,
+        private readonly ?string $validator = null,
+        private readonly array $inputAttributes = [],
+    ) {}
+
+    public function configure(Alert $alert): void
+    {
+        $alert->input($this->input);
+
+        if (null !== $this->label) {
+            $alert->inputLabel($this->label);
+        }
+
+        if (null !== $this->value) {
+            $alert->inputValue($this->value);
+        }
+
+        if (null !== $this->placeholder) {
+            $alert->inputPlaceholder($this->placeholder);
+        }
+
+        if (null !== $this->validator) {
+            $alert->inputValidator($this->validator);
+        }
+
+        if (!empty($this->inputAttributes)) {
+            $alert->inputAttributes($this->inputAttributes);
+        }
+    }
+}

--- a/src/Model/Alert.php
+++ b/src/Model/Alert.php
@@ -82,6 +82,8 @@ final class Alert implements \JsonSerializable
 
     private array $inputAttributes = [];
 
+    private ?string $inputValidator = null;
+
     public static function new(string $title, string $id = '', string $text = '', ?Icon $icon = Icon::SUCCESS, Position $position = Position::BOTTOM_END, array $customClass = []): self
     {
         $alert = new self();
@@ -459,6 +461,18 @@ final class Alert implements \JsonSerializable
         return $this->inputAttributes;
     }
 
+    public function inputValidator(?string $inputValidator): self
+    {
+        $this->inputValidator = $inputValidator;
+
+        return $this;
+    }
+
+    public function getInputValidator(): ?string
+    {
+        return $this->inputValidator;
+    }
+
     public function jsonSerialize(): array
     {
         $data = [
@@ -493,6 +507,7 @@ final class Alert implements \JsonSerializable
             'inputValue'         => $this->inputValue,
             'inputLabel'         => $this->inputLabel,
             'inputAttributes'    => $this->inputAttributes,
+            'inputValidator'     => $this->inputValidator,
         ];
 
         if ($this->toast) {

--- a/tests/AlertManagerTest.php
+++ b/tests/AlertManagerTest.php
@@ -88,6 +88,7 @@ class AlertManagerTest extends KernelTestCase
             'inputValue'         => null,
             'inputLabel'         => null,
             'inputAttributes'    => [],
+            'inputValidator'     => null,
         ];
 
         $this->assertEquals($expectedArray, $alert->jsonSerialize());
@@ -226,6 +227,32 @@ class AlertManagerTest extends KernelTestCase
             $session->getFlashBag()->peekAll(),
             'Alert objects must not be stored in the FlashBag'
         );
+    }
+
+    public function testInputMethod(): void
+    {
+        $textInput = new \Pentiminax\UX\SweetAlert\InputType\Text(
+            label: 'Enter your name',
+            value: 'John Doe',
+            placeholder: 'Name',
+            validator: 'required'
+        );
+
+        $alert = $this->alertManager->input(
+            inputType: $textInput,
+            title: 'Please enter your name',
+            text: 'We need it for verification'
+        );
+
+        $data = $alert->jsonSerialize();
+
+        $this->assertSame('Please enter your name', $data['title']);
+        $this->assertSame('We need it for verification', $data['text']);
+        $this->assertSame('text', $data['input']);
+        $this->assertSame('Enter your name', $data['inputLabel']);
+        $this->assertSame('John Doe', $data['inputValue']);
+        $this->assertSame('Name', $data['inputPlaceholder']);
+        $this->assertSame('required', $data['inputValidator']);
     }
 
     public static function alertMethodProvider(): \Generator

--- a/tests/InputType/TextTest.php
+++ b/tests/InputType/TextTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Pentiminax\UX\SweetAlert\Tests\InputType;
+
+use Pentiminax\UX\SweetAlert\InputType\Text;
+use Pentiminax\UX\SweetAlert\Model\Alert;
+use PHPUnit\Framework\TestCase;
+
+class TextTest extends TestCase
+{
+    public function testConfigure(): void
+    {
+        $alert = Alert::new('Test Alert');
+        $textInput = new Text(
+            label: 'Enter value',
+            value: 'default value',
+            placeholder: 'Wait...',
+            validator: 'validator',
+            inputAttributes: ['maxlength' => '10']
+        );
+
+        $textInput->configure($alert);
+
+        $data = $alert->jsonSerialize();
+
+        $this->assertEquals('text', $data['input']);
+        $this->assertEquals('Enter value', $data['inputLabel']);
+        $this->assertEquals('default value', $data['inputValue']);
+        $this->assertEquals('Wait...', $data['inputPlaceholder']);
+        $this->assertEquals('validator', $data['inputValidator']);
+        $this->assertEquals(['maxlength' => '10'], $data['inputAttributes']);
+    }
+}


### PR DESCRIPTION
Hello. I want to add the feature about input type alert so if anyone wants to add something with input and press by the button, then it will appear as an input type alert. 

Here's the usage example for input type alert:

```php

<?php
use Pentiminax\UX\SweetAlert\InputType\Text;

// ...

$alertManager->input(
    inputType: new Text(label: 'Enter your name', placeholder: 'Name'),
    title: 'Please enter your name'
);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for input-type-driven alerts, enabling users to interact with text input fields.
  * Text inputs can now be configured with labels, placeholders, default values, and validators.
  * Input validation is now available for enhanced form control and data validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->