### PR TITLE
chore: bump minimum PHP version to 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.2', '8.3', '8.4', '8.5']
+        php: ['8.3', '8.4', '8.5']
     name: PHP ${{ matrix.php }} ${{ matrix.description }}
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ UX SweetAlert is a Symfony bundle that integrates the SweetAlert2 library into y
 
 ## Requirements
 
-- PHP 8.2 or higher
+- PHP 8.3 or higher
 - Symfony StimulusBundle
 - Composer
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     }
   },
   "require": {
-    "php": ">=8.2",
+    "php": ">=8.3",
     "symfony/config": "^7.0|^8.0",
     "symfony/dependency-injection": "^7.0|^8.0",
     "symfony/http-kernel": "^7.0|^8.0",


### PR DESCRIPTION
## Summary

- Update `composer.json`: `>=8.2` → `>=8.3`
- Update `README.md`: requirements section
- Update CI matrix: remove PHP 8.2

## Test plan

- [x] CI passes on PHP 8.3, 8.4, 8.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)