### PR TITLE
feat: add callback URL support for AlertManager::input()

### DIFF
--- a/assets/dist/controller.js
+++ b/assets/dist/controller.js
@@ -93,6 +93,7 @@ class default_1 extends Controller {
 
             const swalOptions = Object.assign({}, toast);
             delete swalOptions.callbackUrl;
+            delete swalOptions.id;
 
             const result = await this.fireAlert(swalOptions, this.element);
 

--- a/assets/dist/controller.js
+++ b/assets/dist/controller.js
@@ -89,11 +89,43 @@ class default_1 extends Controller {
         const toasts = this.viewValue;
         for (const toast of toasts) {
             const toastId = toast.id;
-            const result = await this.fireAlert(toast, this.element);
+            const callbackUrl = toast.callbackUrl ?? null;
 
-            document.dispatchEvent(new CustomEvent(`ux-sweet-alert:${toastId}:closed`, {
-                detail: result
-            }));
+            const swalOptions = Object.assign({}, toast);
+            delete swalOptions.callbackUrl;
+
+            const result = await this.fireAlert(swalOptions, this.element);
+
+            if (callbackUrl) {
+                const response = await fetch(callbackUrl, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-Requested-With': 'XMLHttpRequest',
+                    },
+                    body: JSON.stringify({
+                        isConfirmed: result.isConfirmed,
+                        isDenied: result.isDenied,
+                        isDismissed: result.isDismissed,
+                        value: result.value ?? null,
+                    }),
+                    redirect: 'follow',
+                });
+
+                if (response.redirected) {
+                    window.location.href = response.url;
+                } else if (response.headers.get('Content-Type')?.includes('application/json')) {
+                    const data = await response.json();
+                    this.element.dispatchEvent(new CustomEvent('ux-sweet-alert:callback:response', {
+                        bubbles: true,
+                        detail: data,
+                    }));
+                }
+            } else {
+                document.dispatchEvent(new CustomEvent(`ux-sweet-alert:${toastId}:closed`, {
+                    detail: result
+                }));
+            }
         }
     }
 

--- a/assets/dist/controller.js
+++ b/assets/dist/controller.js
@@ -121,6 +121,11 @@ class default_1 extends Controller {
                             bubbles: true,
                             detail: data,
                         }));
+                    } else {
+                        this.element.dispatchEvent(new CustomEvent('ux-sweet-alert:callback:response', {
+                            bubbles: true,
+                            detail: null,
+                        }));
                     }
                 } catch (e) {
                     console.warn('[ux-sweet-alert] Callback URL request failed:', e);

--- a/assets/dist/controller.js
+++ b/assets/dist/controller.js
@@ -97,29 +97,33 @@ class default_1 extends Controller {
             const result = await this.fireAlert(swalOptions, this.element);
 
             if (callbackUrl) {
-                const response = await fetch(callbackUrl, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-Requested-With': 'XMLHttpRequest',
-                    },
-                    body: JSON.stringify({
-                        isConfirmed: result.isConfirmed,
-                        isDenied: result.isDenied,
-                        isDismissed: result.isDismissed,
-                        value: result.value ?? null,
-                    }),
-                    redirect: 'follow',
-                });
+                try {
+                    const response = await fetch(callbackUrl, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-Requested-With': 'XMLHttpRequest',
+                        },
+                        body: JSON.stringify({
+                            isConfirmed: result.isConfirmed,
+                            isDenied: result.isDenied,
+                            isDismissed: result.isDismissed,
+                            value: result.value ?? null,
+                        }),
+                        redirect: 'follow',
+                    });
 
-                if (response.redirected) {
-                    window.location.href = response.url;
-                } else if (response.headers.get('Content-Type')?.includes('application/json')) {
-                    const data = await response.json();
-                    this.element.dispatchEvent(new CustomEvent('ux-sweet-alert:callback:response', {
-                        bubbles: true,
-                        detail: data,
-                    }));
+                    if (response.redirected) {
+                        window.location.href = response.url;
+                    } else if (response.headers.get('Content-Type')?.includes('application/json')) {
+                        const data = await response.json();
+                        this.element.dispatchEvent(new CustomEvent('ux-sweet-alert:callback:response', {
+                            bubbles: true,
+                            detail: data,
+                        }));
+                    }
+                } catch (e) {
+                    console.warn('[ux-sweet-alert] Callback URL request failed:', e);
                 }
             } else {
                 document.dispatchEvent(new CustomEvent(`ux-sweet-alert:${toastId}:closed`, {

--- a/config/services.php
+++ b/config/services.php
@@ -14,6 +14,7 @@ use Pentiminax\UX\SweetAlert\Model\AlertDefaults;
 use Pentiminax\UX\SweetAlert\Twig\Components\ConfirmButton;
 use Pentiminax\UX\SweetAlert\Twig\Components\InputModal;
 use Pentiminax\UX\SweetAlert\Twig\Extension\AlertExtension;
+use Pentiminax\UX\SweetAlert\ValueResolver\ResultValueResolver;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\UX\LiveComponent\LiveResponder;
@@ -112,4 +113,8 @@ return static function (ContainerConfigurator $container) {
         ->arg('$alertManager', new Reference('sweet_alert.alert_manager'))
         ->arg('$twig', new Reference('twig'))
         ->tag('kernel.event_listener', ['event' => 'kernel.response']);
+
+    $services
+        ->set(ResultValueResolver::class)
+        ->tag('controller.argument_value_resolver', ['priority' => 50]);
 };

--- a/src/AlertManager.php
+++ b/src/AlertManager.php
@@ -213,10 +213,15 @@ class AlertManager implements AlertManagerInterface
         Position $position = Position::CENTER,
         ?Theme $theme = null,
         array $customClass = [],
+        string $callback = '',
     ): Alert {
         $alert = $this->createAlert($id, $title, $text, $position, $theme, $icon, $customClass);
 
         $inputType->configure($alert);
+
+        if ($callback !== '') {
+            $alert->callbackUrl($callback);
+        }
 
         $this->addAlert($alert);
 

--- a/src/AlertManagerInterface.php
+++ b/src/AlertManagerInterface.php
@@ -101,5 +101,6 @@ interface AlertManagerInterface
         Position $position = Position::CENTER,
         ?Theme $theme = null,
         array $customClass = [],
+        string $callback = '',
     ): Alert;
 }

--- a/src/Model/Alert.php
+++ b/src/Model/Alert.php
@@ -90,6 +90,8 @@ final class Alert implements \JsonSerializable
 
     private ?string $validationMessage = null;
 
+    private string $callbackUrl = '';
+
     public static function new(string $title, string $id = '', string $text = '', ?Icon $icon = Icon::SUCCESS, Position $position = Position::BOTTOM_END, array $customClass = []): self
     {
         $alert = new self();
@@ -503,6 +505,13 @@ final class Alert implements \JsonSerializable
         return $this->validationMessage;
     }
 
+    public function callbackUrl(string $url): self
+    {
+        $this->callbackUrl = $url;
+
+        return $this;
+    }
+
     public function jsonSerialize(): array
     {
         $data = [
@@ -541,6 +550,10 @@ final class Alert implements \JsonSerializable
             'returnInputValueOnDeny' => $this->returnInputValueOnDeny ?: null,
             'validationMessage'      => $this->validationMessage,
         ];
+
+        if ($this->callbackUrl !== '') {
+            $data['callbackUrl'] = $this->callbackUrl;
+        }
 
         if ($this->toast) {
             $data['toast']            = true;

--- a/src/Model/Alert.php
+++ b/src/Model/Alert.php
@@ -90,7 +90,7 @@ final class Alert implements \JsonSerializable
 
     private ?string $validationMessage = null;
 
-    private string $callbackUrl = '';
+    private ?string $callbackUrl = null;
 
     public static function new(string $title, string $id = '', string $text = '', ?Icon $icon = Icon::SUCCESS, Position $position = Position::BOTTOM_END, array $customClass = []): self
     {
@@ -551,7 +551,7 @@ final class Alert implements \JsonSerializable
             'validationMessage'      => $this->validationMessage,
         ];
 
-        if ($this->callbackUrl !== '') {
+        if (null !== $this->callbackUrl) {
             $data['callbackUrl'] = $this->callbackUrl;
         }
 

--- a/src/ValueResolver/ResultValueResolver.php
+++ b/src/ValueResolver/ResultValueResolver.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\SweetAlert\ValueResolver;
+
+use Pentiminax\UX\SweetAlert\Model\Result;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+final class ResultValueResolver implements ValueResolverInterface
+{
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    {
+        if (Result::class !== $argument->getType()) {
+            return [];
+        }
+
+        $content = $request->getContent();
+
+        if ('' === $content) {
+            return [];
+        }
+
+        $data = json_decode($content, true);
+
+        if (!\is_array($data)) {
+            return [];
+        }
+
+        return [Result::fromArray($data)];
+    }
+}

--- a/tests/AlertManagerTest.php
+++ b/tests/AlertManagerTest.php
@@ -234,6 +234,33 @@ final class AlertManagerTest extends KernelTestCase
         $this->assertSame(Theme::Dark->value, $alert->jsonSerialize()['theme']);
     }
 
+    #[Test]
+    public function it_stores_callback_url_on_input_alert(): void
+    {
+        $alert = $this->alertManager->input(
+            inputType: new \Pentiminax\UX\SweetAlert\InputType\Text(label: 'Name'),
+            title: 'Enter name',
+            callback: '/profile/update',
+        );
+
+        $data = $alert->jsonSerialize();
+
+        $this->assertSame('/profile/update', $data['callbackUrl']);
+    }
+
+    #[Test]
+    public function it_does_not_include_callback_url_when_not_provided(): void
+    {
+        $alert = $this->alertManager->input(
+            inputType: new \Pentiminax\UX\SweetAlert\InputType\Text(label: 'Name'),
+            title: 'Enter name',
+        );
+
+        $data = $alert->jsonSerialize();
+
+        $this->assertArrayNotHasKey('callbackUrl', $data);
+    }
+
     public static function alertMethodProvider(): \Generator
     {
         yield ['success', 'success'];

--- a/tests/Model/AlertTest.php
+++ b/tests/Model/AlertTest.php
@@ -279,4 +279,25 @@ final class AlertTest extends TestCase
 
         $this->assertSame(Theme::Auto->value, $data['theme']);
     }
+
+    #[Test]
+    public function it_includes_callback_url_in_serialized_output(): void
+    {
+        $alert = Alert::new(title: 'Test');
+        $alert->callbackUrl('/api/callback');
+
+        $data = $alert->jsonSerialize();
+
+        $this->assertSame('/api/callback', $data['callbackUrl']);
+    }
+
+    #[Test]
+    public function it_omits_callback_url_from_serialized_output_when_not_set(): void
+    {
+        $alert = Alert::new(title: 'Test');
+
+        $data = $alert->jsonSerialize();
+
+        $this->assertArrayNotHasKey('callbackUrl', $data);
+    }
 }

--- a/tests/ValueResolver/ResultValueResolverTest.php
+++ b/tests/ValueResolver/ResultValueResolverTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pentiminax\UX\SweetAlert\Tests\ValueResolver;
+
+use Pentiminax\UX\SweetAlert\Model\Result;
+use Pentiminax\UX\SweetAlert\ValueResolver\ResultValueResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+/**
+ * @internal
+ */
+#[CoversClass(ResultValueResolver::class)]
+final class ResultValueResolverTest extends TestCase
+{
+    private ResultValueResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new ResultValueResolver();
+    }
+
+    #[Test]
+    public function it_resolves_result_from_json_body(): void
+    {
+        $request = Request::create('/', 'POST', content: json_encode([
+            'isConfirmed' => true,
+            'isDenied'    => false,
+            'isDismissed' => false,
+            'value'       => 'Tanguy',
+        ]));
+
+        $argument = $this->createArgumentMetadata(Result::class);
+
+        $results = [...$this->resolver->resolve($request, $argument)];
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(Result::class, $results[0]);
+        $this->assertTrue($results[0]->isConfirmed);
+        $this->assertFalse($results[0]->isDenied);
+        $this->assertFalse($results[0]->isDismissed);
+        $this->assertSame('Tanguy', $results[0]->value);
+    }
+
+    #[Test]
+    public function it_resolves_dismissed_result(): void
+    {
+        $request = Request::create('/', 'POST', content: json_encode([
+            'isConfirmed' => false,
+            'isDenied'    => false,
+            'isDismissed' => true,
+            'value'       => null,
+        ]));
+
+        $argument = $this->createArgumentMetadata(Result::class);
+
+        $results = [...$this->resolver->resolve($request, $argument)];
+
+        $this->assertCount(1, $results);
+        $this->assertFalse($results[0]->isConfirmed);
+        $this->assertTrue($results[0]->isDismissed);
+        $this->assertNull($results[0]->value);
+    }
+
+    #[Test]
+    public function it_returns_empty_when_argument_type_is_not_result(): void
+    {
+        $request  = Request::create('/', 'POST', content: '{}');
+        $argument = $this->createArgumentMetadata(\stdClass::class);
+
+        $results = [...$this->resolver->resolve($request, $argument)];
+
+        $this->assertEmpty($results);
+    }
+
+    #[Test]
+    public function it_returns_empty_when_body_is_not_valid_json(): void
+    {
+        $request  = Request::create('/', 'POST', content: 'not-json');
+        $argument = $this->createArgumentMetadata(Result::class);
+
+        $results = [...$this->resolver->resolve($request, $argument)];
+
+        $this->assertEmpty($results);
+    }
+
+    #[Test]
+    public function it_returns_empty_when_body_is_empty(): void
+    {
+        $request  = Request::create('/', 'POST', content: '');
+        $argument = $this->createArgumentMetadata(Result::class);
+
+        $results = [...$this->resolver->resolve($request, $argument)];
+
+        $this->assertEmpty($results);
+    }
+
+    private function createArgumentMetadata(string $type): ArgumentMetadata
+    {
+        $argument = $this->createMock(ArgumentMetadata::class);
+        $argument->method('getType')->willReturn($type);
+
+        return $argument;
+    }
+}


### PR DESCRIPTION
## Summary

- Ajoute un paramètre `callback` (URL) à `AlertManager::input()` pour récupérer la valeur d'un input SweetAlert2 côté PHP
- Crée un `ResultValueResolver` Symfony qui désérialise automatiquement le JSON body d'une requête POST en objet `Result`
- Met à jour le Stimulus controller pour détecter le `callbackUrl` et faire un `fetch` POST avec le résultat après confirmation

## Usage

```php
// Création de l'alerte avec callback URL
$alertManager->input(
    inputType: new Text(
        label: 'Display name',
        value: 'Tanguy',
        placeholder: 'Enter your display name',
    ),
    title: 'Update profile',
    text: 'This change is visible to other users.',
    callback: $this->generateUrl('app_profile_update'),
);

// Récupération de la valeur — le Result est injecté automatiquement
#[Route('/profile/update', name: 'app_profile_update', methods: ['POST'])]
public function updateProfile(Result $result): Response
{
    if ($result->isConfirmed) {
        $this->userService->updateDisplayName($result->value);
    }
    return $this->redirectToRoute('app_profile');
    // ou : return $this->json(['status' => 'ok']);
}
```

## Comportement JS

- Si `callbackUrl` est présent : `fetch` POST avec `{ isConfirmed, isDenied, isDismissed, value }` en JSON body
- Réponse redirect → `window.location.href` suit le redirect
- Réponse JSON → dispatch de l'event `ux-sweet-alert:callback:response` sur l'élément
- Autre réponse 2xx → dispatch de `ux-sweet-alert:callback:response` avec `detail: null`
- Erreur réseau → `console.warn` (pas de crash)
- Sans `callbackUrl` → comportement existant inchangé (LiveComponent flow)

## Test Plan

- [ ] Vérifier qu'un `alertManager->input()` sans `callback` fonctionne comme avant
- [ ] Vérifier qu'avec `callback: '/url'`, la valeur saisie arrive bien dans `Result $result` du controller
- [ ] Vérifier qu'un redirect depuis le controller callback redirige la page
- [ ] Vérifier qu'une `JsonResponse` déclenche l'event `ux-sweet-alert:callback:response`
- [ ] `vendor/bin/phpunit` : 77 tests, 0 échec

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Alerts now support callback URLs to handle user responses
  * Alert input method accepts an optional callback parameter to specify custom response endpoints

* **Tests**
  * Added comprehensive test coverage for callback URL handling and automatic response processing across multiple scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->